### PR TITLE
make host and port configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ### Changed
-- Allow custom host and port configurable for 3scale On premise SAAS platform [PR #16](https://github.com/3scale/3scale_ws_api_for_php/pull/16)
+- Allow custom host and port configurable for 3scale On premise SAAS platform [PR #16](https://github.com/3scale/3scale_ws_api_for_php/.)  Note: For example, the signature is changed from ```$url = "http://" . $this->getHost() . "/transactions/authorize.xml"``` to ```$url = $this->getHost() . "/transactions/oauth_authorize.xml";``` for endpoints
 
 ##[2.7.0] - 2017-02-16
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Changed
+- Allow custom host and port configurable for 3scale On premise SAAS platform [PR #16](https://github.com/3scale/3scale_ws_api_for_php/pull/16)
+
 ##[2.7.0] - 2017-02-16
 ### Added
 - Added support for (Service Tokens)[https://support.3scale.net/docs/accounts/tokens]

--- a/lib/ThreeScaleClient.php
+++ b/lib/ThreeScaleClient.php
@@ -17,13 +17,17 @@ require_once(dirname(__FILE__) . '/ThreeScaleAuthorizeResponse.php');
  *
  * Objects of this class are stateless and can be shared through multiple
  * transactions and by multiple clients.
+ * DEFAULT_HOST = su1.3scale.et communicates with 3scale saas platform. When connecting to an on-premise instance of the  3scale platform replace it with correct host and port
  */
 class ThreeScaleClient {
   const DEFAULT_HOST = 'su1.3scale.net';
+  const DEFAULT_PORT = '80';
 
   private $providerKey = null;
   private $host;
   private $httpClient;
+  private $port;
+
 
   /**
    * Create a ThreeScaleClient instance.
@@ -34,13 +38,14 @@ class ThreeScaleClient {
    * @param $httpClient Object Object for handling HTTP requests. Default is CURL. Don't change it
    *                    unless you know what you are doing.
    */
-  public function __construct($providerKey = null, $host = self::DEFAULT_HOST, $httpClient = null) {
+  public function __construct($providerKey = null, $host = self::DEFAULT_HOST, $port = self::DEFAULT_PORT, $httpClient = null) {
     if ($providerKey) {
       $this->providerKey = $providerKey;
     } 
 
     $this->host = $host;
     $this->setHttpClient($httpClient);
+    $this->port = $port;
   }
 
   /**
@@ -52,11 +57,19 @@ class ThreeScaleClient {
   }
 
   /**
-   * Get hostname of 3scale backend server.
+   * Get hostname of backend server.
    * @return string
    */
   public function getHost() {
     return $this->host;
+  }
+
+  /**
+   * Get port of the backend server.
+   * @return string
+   */
+  public function getPort() {
+    return $this->port;
   }
 
   /**
@@ -94,7 +107,7 @@ class ThreeScaleClient {
    */
   
      public function authorize($appId, $appKey = null, $credentials_or_service_id, $usage = null) {
-    $url = "http://" . $this->getHost() . "/transactions/authorize.xml";
+    $url = "http://" . $this->getHost() . ":" . $this->getPort() . "/transactions/authorize.xml";
     $params = array('app_id' => $appId);
 
     if ($credentials_or_service_id instanceof ThreeScaleClientCredentials ) {
@@ -156,7 +169,7 @@ class ThreeScaleClient {
    * </code>
    */
   public function oauth_authorize($appId, $credentials_or_service_id, $usage = null) {
-    $url = "http://" . $this->getHost() . "/transactions/oauth_authorize.xml";
+    $url = "http://" . $this->getHost() . ":" . $this->getPort() . "/transactions/oauth_authorize.xml";
     $params = array('app_id' => $appId);
 
    if ($credentials_or_service_id instanceof ThreeScaleClientCredentials ) {
@@ -215,7 +228,7 @@ class ThreeScaleClient {
    */
 
   public function authorize_with_user_key($userKey, $credentials_or_service_id, $usage = null) {
-    $url = "http://" . $this->getHost() . "/transactions/authorize.xml";
+    $url = "http://" . $this->getHost() . ":" . $this->getPort() . "/transactions/authorize.xml";
     $params = array('user_key' => $userKey);
     
     if ($credentials_or_service_id instanceof ThreeScaleClientCredentials ) {
@@ -275,7 +288,7 @@ class ThreeScaleClient {
    */
 
    public function authrep($appId, $appKey = null, $credentials_or_service_id, $usage = null, $userId = null, $object = null, $no_body = null) {  
-    $url = "http://" . $this->getHost() . "/transactions/authrep.xml";
+    $url = "http://" . $this->getHost() . ":" . $this->getPort() . "/transactions/authrep.xml";
 
     $params = array('app_id' => $appId);
 
@@ -337,7 +350,7 @@ class ThreeScaleClient {
    */
 
   public function authrep_with_user_key($userKey, $credentials_or_service_id, $usage = null, $userId = null, $object = null, $no_body = null) {  
-    $url = "http://" . $this->getHost() . "/transactions/authrep.xml";
+    $url = "http://" . $this->getHost() . ":" . $this->getPort() . "/transactions/authrep.xml";
 
     $params = array('user_key' => $userKey);
 
@@ -429,7 +442,7 @@ class ThreeScaleClient {
       throw new InvalidArgumentException('no transactions to report');
     }
     
-    $url = "http://" . $this->getHost() . "/transactions.xml";
+    $url = "http://" . $this->getHost() . ":" . $this->getPort() . "/transactions.xml";
 
     $params = array();
 

--- a/lib/ThreeScaleClient.php
+++ b/lib/ThreeScaleClient.php
@@ -20,12 +20,14 @@ require_once(dirname(__FILE__) . '/ThreeScaleAuthorizeResponse.php');
  * DEFAULT_HOST = su1.3scale.et communicates with 3scale saas platform. When connecting to an on-premise instance of the  3scale platform replace it with correct host and port
  */
 class ThreeScaleClient {
+  const DEFAULT_SCHEME = 'http';
   const DEFAULT_HOST = 'su1.3scale.net';
   const DEFAULT_PORT = '80';
 
   private $providerKey = null;
-  private $host;
   private $httpClient;
+  private $scheme;
+  private $host;
   private $port;
 
 
@@ -38,14 +40,15 @@ class ThreeScaleClient {
    * @param $httpClient Object Object for handling HTTP requests. Default is CURL. Don't change it
    *                    unless you know what you are doing.
    */
-  public function __construct($providerKey = null, $host = self::DEFAULT_HOST, $port = self::DEFAULT_PORT, $httpClient = null) {
+  public function __construct($providerKey = null, $host = self::DEFAULT_HOST, $port = self::DEFAULT_PORT, $scheme = self::DEFAULT_SCHEME, $httpClient = null) {
     if ($providerKey) {
       $this->providerKey = $providerKey;
     } 
 
-    $this->host = $host;
     $this->setHttpClient($httpClient);
-    $this->port = $port;
+    $this->scheme = $scheme;
+    $this->host   = $host;
+    $this->port   = $port;
   }
 
   /**
@@ -70,6 +73,14 @@ class ThreeScaleClient {
    */
   public function getPort() {
     return $this->port;
+  }
+
+  /**
+   * Get scheme of the backend server. 'https' for SSL otherwise 'http'
+   * @return string
+   */
+  public function getScheme() {
+    return $this->scheme;
   }
 
   /**
@@ -107,7 +118,7 @@ class ThreeScaleClient {
    */
   
      public function authorize($appId, $appKey = null, $credentials_or_service_id, $usage = null) {
-    $url = "http://" . $this->getHost() . ":" . $this->getPort() . "/transactions/authorize.xml";
+    $url = $this->getScheme(). "://" . $this->getHost() . ":" . $this->getPort() . "/transactions/authorize.xml";
     $params = array('app_id' => $appId);
 
     if ($credentials_or_service_id instanceof ThreeScaleClientCredentials ) {
@@ -169,7 +180,7 @@ class ThreeScaleClient {
    * </code>
    */
   public function oauth_authorize($appId, $credentials_or_service_id, $usage = null) {
-    $url = "http://" . $this->getHost() . ":" . $this->getPort() . "/transactions/oauth_authorize.xml";
+    $url = $this->getScheme(). "://" . $this->getHost() . ":" . $this->getPort() . "/transactions/oauth_authorize.xml";
     $params = array('app_id' => $appId);
 
    if ($credentials_or_service_id instanceof ThreeScaleClientCredentials ) {
@@ -228,7 +239,7 @@ class ThreeScaleClient {
    */
 
   public function authorize_with_user_key($userKey, $credentials_or_service_id, $usage = null) {
-    $url = "http://" . $this->getHost() . ":" . $this->getPort() . "/transactions/authorize.xml";
+    $url = $this->getScheme(). "://" . $this->getHost() . ":" . $this->getPort() . "/transactions/authorize.xml";
     $params = array('user_key' => $userKey);
     
     if ($credentials_or_service_id instanceof ThreeScaleClientCredentials ) {
@@ -288,7 +299,7 @@ class ThreeScaleClient {
    */
 
    public function authrep($appId, $appKey = null, $credentials_or_service_id, $usage = null, $userId = null, $object = null, $no_body = null) {  
-    $url = "http://" . $this->getHost() . ":" . $this->getPort() . "/transactions/authrep.xml";
+    $url = $this->getScheme(). "://" . $this->getHost() . ":" . $this->getPort() . "/transactions/authrep.xml";
 
     $params = array('app_id' => $appId);
 
@@ -350,7 +361,7 @@ class ThreeScaleClient {
    */
 
   public function authrep_with_user_key($userKey, $credentials_or_service_id, $usage = null, $userId = null, $object = null, $no_body = null) {  
-    $url = "http://" . $this->getHost() . ":" . $this->getPort() . "/transactions/authrep.xml";
+    $url = $this->getScheme(). "://" . $this->getHost() . ":" . $this->getPort() . "/transactions/authrep.xml";
 
     $params = array('user_key' => $userKey);
 
@@ -442,7 +453,7 @@ class ThreeScaleClient {
       throw new InvalidArgumentException('no transactions to report');
     }
     
-    $url = "http://" . $this->getHost() . ":" . $this->getPort() . "/transactions.xml";
+    $url = $this->getScheme(). "://" . $this->getHost() . ":" . $this->getPort() . "/transactions.xml";
 
     $params = array();
 

--- a/lib/ThreeScaleClient.php
+++ b/lib/ThreeScaleClient.php
@@ -17,38 +17,30 @@ require_once(dirname(__FILE__) . '/ThreeScaleAuthorizeResponse.php');
  *
  * Objects of this class are stateless and can be shared through multiple
  * transactions and by multiple clients.
- * DEFAULT_HOST = su1.3scale.et communicates with 3scale saas platform. When connecting to an on-premise instance of the  3scale platform replace it with correct host and port
+ * DEFAULT_ROOT_ENDPOINT  su1.3scale.net communicates with 3scale SAAS platform. When connecting to an on-premise instance of the  3scale platform, replace it with correct scheme, host and port
  */
 class ThreeScaleClient {
-  const DEFAULT_SCHEME = 'http';
-  const DEFAULT_HOST = 'su1.3scale.net';
-  const DEFAULT_PORT = '80';
+  const DEFAULT_ROOT_ENDPOINT = 'http://su1.3scale.net';
 
   private $providerKey = null;
   private $httpClient;
-  private $scheme;
   private $host;
-  private $port;
-
 
   /**
    * Create a ThreeScaleClient instance.
    *
    * @param $providerKey If (!Provider Key) then service token workflow is triggered.
-   * @param $host String Hostname of 3scale backend server. Usually there is no reason to use anything
-   *              else than the default value.
+   * @param $host String scheme + hostname + port of 3scale backend server or On-premise 3scale SAAS platform
    * @param $httpClient Object Object for handling HTTP requests. Default is CURL. Don't change it
    *                    unless you know what you are doing.
    */
-  public function __construct($providerKey = null, $host = self::DEFAULT_HOST, $port = self::DEFAULT_PORT, $scheme = self::DEFAULT_SCHEME, $httpClient = null) {
+  public function __construct($providerKey = null, $host = self::DEFAULT_ROOT_ENDPOINT, $httpClient = null) {
     if ($providerKey) {
       $this->providerKey = $providerKey;
     } 
 
     $this->setHttpClient($httpClient);
-    $this->scheme = $scheme;
     $this->host   = $host;
-    $this->port   = $port;
   }
 
   /**
@@ -65,22 +57,6 @@ class ThreeScaleClient {
    */
   public function getHost() {
     return $this->host;
-  }
-
-  /**
-   * Get port of the backend server.
-   * @return string
-   */
-  public function getPort() {
-    return $this->port;
-  }
-
-  /**
-   * Get scheme of the backend server. 'https' for SSL otherwise 'http'
-   * @return string
-   */
-  public function getScheme() {
-    return $this->scheme;
   }
 
   /**
@@ -118,7 +94,7 @@ class ThreeScaleClient {
    */
   
      public function authorize($appId, $appKey = null, $credentials_or_service_id, $usage = null) {
-    $url = $this->getScheme(). "://" . $this->getHost() . ":" . $this->getPort() . "/transactions/authorize.xml";
+    $url =  $this->getHost() . "/transactions/authorize.xml";
     $params = array('app_id' => $appId);
 
     if ($credentials_or_service_id instanceof ThreeScaleClientCredentials ) {
@@ -180,7 +156,7 @@ class ThreeScaleClient {
    * </code>
    */
   public function oauth_authorize($appId, $credentials_or_service_id, $usage = null) {
-    $url = $this->getScheme(). "://" . $this->getHost() . ":" . $this->getPort() . "/transactions/oauth_authorize.xml";
+    $url = $this->getHost() . "/transactions/oauth_authorize.xml";
     $params = array('app_id' => $appId);
 
    if ($credentials_or_service_id instanceof ThreeScaleClientCredentials ) {
@@ -239,7 +215,7 @@ class ThreeScaleClient {
    */
 
   public function authorize_with_user_key($userKey, $credentials_or_service_id, $usage = null) {
-    $url = $this->getScheme(). "://" . $this->getHost() . ":" . $this->getPort() . "/transactions/authorize.xml";
+    $url = $this->getHost() . "/transactions/authorize.xml";
     $params = array('user_key' => $userKey);
     
     if ($credentials_or_service_id instanceof ThreeScaleClientCredentials ) {
@@ -299,7 +275,7 @@ class ThreeScaleClient {
    */
 
    public function authrep($appId, $appKey = null, $credentials_or_service_id, $usage = null, $userId = null, $object = null, $no_body = null) {  
-    $url = $this->getScheme(). "://" . $this->getHost() . ":" . $this->getPort() . "/transactions/authrep.xml";
+    $url = $this->getHost() . "/transactions/authrep.xml";
 
     $params = array('app_id' => $appId);
 
@@ -361,7 +337,7 @@ class ThreeScaleClient {
    */
 
   public function authrep_with_user_key($userKey, $credentials_or_service_id, $usage = null, $userId = null, $object = null, $no_body = null) {  
-    $url = $this->getScheme(). "://" . $this->getHost() . ":" . $this->getPort() . "/transactions/authrep.xml";
+    $url = $this->getHost() . "/transactions/authrep.xml";
 
     $params = array('user_key' => $userKey);
 
@@ -453,7 +429,7 @@ class ThreeScaleClient {
       throw new InvalidArgumentException('no transactions to report');
     }
     
-    $url = $this->getScheme(). "://" . $this->getHost() . ":" . $this->getPort() . "/transactions.xml";
+    $url = $this->getHost() . "/transactions.xml";
 
     $params = array();
 

--- a/test/ThreeScaleClientTest.php
+++ b/test/ThreeScaleClientTest.php
@@ -159,7 +159,7 @@ class ThreeScaleClientTest extends UnitTestCase {
   
   function testReportEncodesTransactions() {
     $this->httpClient->expectOnce('post',
-      array('http://' . ThreeScaleClient::DEFAULT_HOST . '/transactions.xml',
+      array('http://' . ThreeScaleClient::DEFAULT_HOST .  ":" . ThreeScaleClient::DEFAULT_PORT.'/transactions.xml',
         array(
           'service_token' => '12345',
           'service_id' => '12345',

--- a/test/ThreeScaleClientTest.php
+++ b/test/ThreeScaleClientTest.php
@@ -38,7 +38,7 @@ class ThreeScaleClientTest extends UnitTestCase {
   function testDefaultHost() {
     $client = new ThreeScaleClient('1234abcd');
 
-    $this->assertEqual('su1.3scale.net', $client->getHost());
+    $this->assertEqual('http://su1.3scale.net', $client->getHost());
   }
   
   function testSuccessfulAuthorize() {
@@ -159,7 +159,7 @@ class ThreeScaleClientTest extends UnitTestCase {
   
   function testReportEncodesTransactions() {
     $this->httpClient->expectOnce('post',
-      array(ThreeScaleClient::DEFAULT_SCHEME . '://' . ThreeScaleClient::DEFAULT_HOST .  ":" . ThreeScaleClient::DEFAULT_PORT.'/transactions.xml',
+      array(ThreeScaleClient::DEFAULT_ROOT_ENDPOINT . '/transactions.xml',
         array(
           'service_token' => '12345',
           'service_id' => '12345',

--- a/test/ThreeScaleClientTest.php
+++ b/test/ThreeScaleClientTest.php
@@ -159,7 +159,7 @@ class ThreeScaleClientTest extends UnitTestCase {
   
   function testReportEncodesTransactions() {
     $this->httpClient->expectOnce('post',
-      array('http://' . ThreeScaleClient::DEFAULT_HOST .  ":" . ThreeScaleClient::DEFAULT_PORT.'/transactions.xml',
+      array(ThreeScaleClient::DEFAULT_SCHEME . '://' . ThreeScaleClient::DEFAULT_HOST .  ":" . ThreeScaleClient::DEFAULT_PORT.'/transactions.xml',
         array(
           'service_token' => '12345',
           'service_id' => '12345',


### PR DESCRIPTION
**Earlier working with 3scale SaaS platform**
DEFAULT_HOST = 'su1.3scale.net';
//default port was 80

**For on-premise configuration, the customer needs to change the host and port like below**
  const DEFAULT_HOST = 'host';
  const DEFAULT_PORT = '8090';

Verified this on mock backend that returned 200ok with authorization xml and could successfully verify the calls

```
GET /transactions/authorize.xml?app_id=<app_id>&service_token=<service_token>&service_id=<service_id>&app_key=<app_key> HTTP/1.1
User-Agent: curl/7.43.0
Host: ec2-107-22-51-90.compute-1.amazonaws.com:8090
Accept: */*
```
