### PR TITLE
Add client header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,11 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Added
+- Added client header ```X-3scale-User-Agent: plugin-php-v{version-number} 
+
 ### Changed
-- Allow custom host and port configurable for 3scale On premise SAAS platform [PR #16](https://github.com/3scale/3scale_ws_api_for_php/.)  Note: For example, the signature is changed from ```$url = "http://" . $this->getHost() . "/transactions/authorize.xml"``` to ```$url = $this->getHost() . "/transactions/oauth_authorize.xml";``` for endpoints
+- Allow custom host and port configurable for 3scale On premise SAAS platform [PR #16](https://github.com/3scale/3scale_ws_api_for_php/pull/16)  Note: For example, the signature is changed from ```$url = "http://" . $this->getHost() . "/transactions/authorize.xml"``` to ```$url = $this->getHost() . "/transactions/oauth_authorize.xml";``` for endpoints
 
 ##[2.7.0] - 2017-02-16
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
-## Unreleased
+## 2.7.1
 
 ### Added
-- Added client header ```X-3scale-User-Agent: plugin-php-v{version-number} 
+- Added client header ```X-3scale-User-Agent: plugin-php-v{version-number} [PR #17](https://github.com/3scale/3scale_ws_api_for_php/pull/17)
 
 ### Changed
 - Allow custom host and port configurable for 3scale On premise SAAS platform [PR #16](https://github.com/3scale/3scale_ws_api_for_php/pull/16)  Note: For example, the signature is changed from ```$url = "http://" . $this->getHost() . "/transactions/authorize.xml"``` to ```$url = $this->getHost() . "/transactions/oauth_authorize.xml";``` for endpoints

--- a/lib/ThreeScaleClient.php
+++ b/lib/ThreeScaleClient.php
@@ -10,6 +10,7 @@ require_once(dirname(__FILE__) . '/curl/curl.php');
 
 require_once(dirname(__FILE__) . '/ThreeScaleResponse.php');
 require_once(dirname(__FILE__) . '/ThreeScaleAuthorizeResponse.php');
+require_once(dirname(__FILE__) . '/version.php');
 
 
 /**
@@ -557,7 +558,12 @@ class ThreeScaleClient {
   public function setHttpClient($httpClient) {
     if (is_null($httpClient)) {
       $httpClient = new Curl;
+      $threeScaleVersion = new ThreeScaleVersion();
+
+      $version = $threeScaleVersion->getVersion();
+
       $httpClient->options['CURLOPT_FOLLOWLOCATION'] = false;
+      $httpClient->headers['X-3scale-User-Agent'] = 'plugin-php-v'. $version;
     }
 
     $this->httpClient = $httpClient;

--- a/lib/version.php
+++ b/lib/version.php
@@ -1,0 +1,15 @@
+<?php 
+
+/*
+** Defines ThreeScaleVersion class
+*/
+
+class ThreeScaleVersion {
+	private $version = '2.7.1';
+
+	public function getVersion() {
+		return $this->version;
+	}
+}
+
+?>


### PR DESCRIPTION
The header `X-3scale-User-Agent` is successfully added to outgoing request. Below example of calls

**1) Authorize call**
```
GET /transactions/authorize.xml?app_id=<app_id>&service_token=<service_id>&service_id=<service_id>&app_key=<app_key> HTTP/1.1
User-Agent: curl/7.43.0
Host: ec2-107-22-51-90.compute-1.amazonaws.com:8090
Accept: */*
Referer:
X-3scale-User-Agent: plugin-php-v2.7.1
```

**2) Report call**
```
POST /transactions.xml HTTP/1.1
User-Agent: curl/7.43.0
Host: ec2-107-22-51-90.compute-1.amazonaws.com:8090
Accept: */*
Referer:
X-3scale-User-Agent: plugin-php-v2.7.1
Content-Length: 189
Content-Type: application/x-www-form-urlencoded
```