### PR TITLE
Update user_key auth_rep example

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -139,7 +139,7 @@ $response->getPlan()
 You can also use other patterns such as `user_key` mode during the authrep call
 
 ```php
-$response = $client->authrep_with_user_key("app id", "app key", new ThreeScaleClientCredentials("service id", "service token"), array('hits' => 1));
+$response = $client->authrep_with_user_key("user_key", new ThreeScaleClientCredentials("service id", "service token"), array('hits' => 1));
 ```
 
 ### Report


### PR DESCRIPTION
In the user_key auth_rep example it says

```$response = $client->authrep_with_user_key("app id", "app key", new ThreeScaleClientCredentials("service id", "service token"), array('hits' => 1));``` 

but should probably be

```$response = $client->authrep_with_user_key(”user_key", new ThreeScaleClientCredentials("service id", "service token"), array('hits' => 1));```